### PR TITLE
Make startx boot option work with systemd

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -1337,10 +1337,6 @@ config_stats() {
 # {{{ start X window system via grml-x
 config_x_startup(){
 
-  if $SYSTEMD ; then
-    ewarn "The startx boot option isn't yet supported via systemd, sorry." ; eend 0
-    return
-  fi
 
 # make sure we start X only if startx is used *before* a nostartx option
 # so it's possible to disable automatic X startup using nostart
@@ -1355,17 +1351,28 @@ if checkbootparam 'startx' && ! echo "$CMDLINE" | grep -q 'startx.*nostartx' ; t
    fi
    einfo "Setting up and invoking grml-x ${WINDOWMANAGER}. Just exit X windows system to get full featured consoles."
    config_userlocal
- cat>|/etc/init.d/xstartup<<EOF
+   if $SYSTEMD ; then
+     cat>|/etc/init.d/startx<<EOF
 #!/bin/sh
-su $localuser -c "/usr/bin/grml-x ${WINDOWMANAGER}"
+chgrp tty ${TTY}
+chmod g=rw ${TTY}
+sudo -u "${localuser}" /usr/bin/grml-x "${WINDOWMANAGER}"
 EOF
-   chmod 755 /etc/init.d/xstartup
+     chmod 755 /etc/init.d/startx
+     chvt 6
+     return
+   fi
+   cat>|/etc/init.d/startx<<EOF
+#!/bin/sh
+su "${localuser}" -c "/usr/bin/grml-x ${WINDOWMANAGER}"
+EOF
+   chmod 755 /etc/init.d/startx
 
-   # adjust inittab for xstartup
+   # adjust inittab for startx
    if grep -q '^6:' /etc/inittab ; then
-      sed -i 's|^6:.*|6:2345:respawn:/bin/zsh --login -c "/etc/init.d/xstartup ; /usr/share/grml-scripts/run-welcome" >/dev/tty6 2>\&1 </dev/tty6|' /etc/inittab
+      sed -i 's|^6:.*|6:2345:respawn:/bin/zsh --login -c "/etc/init.d/startx ; /usr/share/grml-scripts/run-welcome" >/dev/tty6 2>\&1 </dev/tty6|' /etc/inittab
    else # just append tty6 to inittab if no definition is present:
-      echo '6:2345:respawn:/bin/zsh --login -c "/etc/init.d/xstartup ; /usr/share/grml-scripts/run-welcome" >/dev/tty6 2>&1 < /dev/tty6' >> /etc/inittab
+      echo '6:2345:respawn:/bin/zsh --login -c "/etc/init.d/startx ; /usr/share/grml-scripts/run-welcome" >/dev/tty6 2>&1 < /dev/tty6' >> /etc/inittab
    fi
 
    /sbin/telinit q ; eend $?


### PR DESCRIPTION
The desired behavior (with systemd and the boot option "startx") is to start
the X window system automatically.

This is achieved by getty@tty6.service which starts grml-x as user "grml" on
vt6/tty6 and switches back to vt1/tty1 after exit. (This alone could be
achieved with systemd-unit option Type=oneshot and Restart=no). But when
switiching back to vt6/tty6 (again) we would like to start a zsh (for user
"grml") and restart the zsh if exited. That means that grml-x should only be
started on the very first run and the zsh on every other.

We could not figure out how to change the systemd-unit option "Type"
dynamically, so we kept it on "idle" which means that the "actual execution of
the service binary is delayed until all active jobs are dispatched". That's why
we need to switch to vt6/tty6 (via grml-autoconfig) iff the boot option
"startx" is given.

We also do not know yet how to dynamically change the behavior of the
systemd-unit in a safe way. Rewriting the unit-file (override.conf) after
grml-x exits (i.e. with ExecStopPost) doesn't seem to work reliably (especially
when calling "systemctl daemon-reload" in it). That's why we use a state-file
(/var/run/grml_startx.started) to start up grml-x on the first call and the zsh
else.

This also means that grml-x is started automatically when switching to vt6/tty6
manually (when no "startx" boot option was given) once and the zsh on the
following calls.

Closes grml/grml#1