### PR TITLE
Fix generation of startx helper script

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -1375,9 +1375,9 @@ if checkbootparam 'startx' && ! echo "$CMDLINE" | grep -q 'startx.*nostartx' ; t
    if $SYSTEMD ; then
      cat>|/etc/init.d/startx<<EOF
 #!/bin/sh
-chgrp tty ${TTY}
-chmod g=rw ${TTY}
-sudo -u "${localuser}" /usr/bin/grml-x "${WINDOWMANAGER}"
+chgrp tty \${TTY}
+chmod g=rw \${TTY}
+sudo -u "${localuser}" /usr/bin/grml-x ${WINDOWMANAGER}
 EOF
      chmod 755 /etc/init.d/startx
      chvt 6


### PR DESCRIPTION
`/etc/init.d/startx` is created dynamically on startup.  The $ of ${TTY}
was not escaped so that when generating the helper script the variable
was evaluated which lead to an empty output.

The script fixes permission problems of /dev/ttyX when grml-x is started
via sudo.

Usually /dev/ttyX is owned by root:tty and has 0620 permission but
grml-runtty changes ownership to root:root to overcome other problems.
(It is not clear if these problems are still present and if we still
have to do this but for now we provide this helper script).

${WINDOWMANAGER} is evaluated on generation and can be (and usually is)
empty. But when starting grml-x with the parameter "" this leads to an
immediate exit of grml-x. Removed the surrounding "".