### PR TITLE
Get rid of ugly startx helper script and start X on tty7/vt7

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -1319,14 +1319,7 @@ if checkbootparam 'startx' && ! echo "$CMDLINE" | grep -q 'startx.*nostartx' ; t
    einfo "Setting up and invoking grml-x ${WINDOWMANAGER}. Just exit X windows system to get full featured consoles."
    config_userlocal
    if $SYSTEMD ; then
-     cat>|/etc/init.d/startx<<EOF
-#!/bin/sh
-chgrp tty \${TTY}
-chmod g=rw \${TTY}
-sudo -u "${localuser}" /usr/bin/grml-x ${WINDOWMANAGER}
-EOF
-     chmod 755 /etc/init.d/startx
-     chvt 6
+     chvt 7
      return
    fi
    cat>|/etc/init.d/startx<<EOF


### PR DESCRIPTION
The startx helper script was used to get around some permission problems
which were caused by grml-runtty. As we switched to agetty, we also can
get rid of this ugly hack.

Furthermore we decided to start X on tty7/vt7 (if the bootoption startx
is given) as tty6 "is especially reserved for auto-spawned gettys":

 This is done in order to ensure that there's always a way to get a text
 login, even if due to fast user switching X took possession of more
 than 5 VTs.

See: http://0pointer.de/blog/projects/serial-console.html

Relates to grml/grml#20