### PR TITLE
Fix the amixer scontrols parser in config_mixer

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -892,8 +892,7 @@ else
       eindent
         SKIP_CPU_GOVERNOR=1
         oldIFS="$IFS"
-        IFS="
-"
+        IFS=$'\n'
          for line in $(grep FATAL "$LOADCPUFREQ" | sed 's/.*FATAL: //; s/ (.*)//') ; do
              eerror "$line" ; eend $RC
          done
@@ -1155,8 +1154,7 @@ config_mixer () {
 
       CONTROLS=$(amixer -c $card scontrols | awk -F"Simple mixer control " '{print $2}')
       IFSOLD=${IFS:-}
-      IFS='
-      '
+      IFS=$'\n'
       for CONTROL in ${=CONTROLS} ; do
         # such devices can not be controlled with amixer ... unmute
         [[ "$CONTROL" == *Console* ]] && continue
@@ -1607,8 +1605,7 @@ config_swraid(){
           einfo "Bootoption swraid found. Searching for software RAID arrays:"
           eindent
            IFSOLD=${IFS:-}
-           IFS='
-'
+           IFS=$'\n'
            for line in $(mdadm --assemble --scan --auto=yes --symlink=no 2>&1) ; do
                case $line in
                  *'No arrays found'*)
@@ -1629,8 +1626,7 @@ config_swraid(){
                ewarn "No active arrays found" ; eend 0
             else
                IFSOLD=${IFS:-}
-               IFS='
-'
+               IFS=$'\n'
                for line in $(grep '^md[0-9]' /proc/mdstat) ; do
                    einfo "active arrays: $line" ; eend 0
                done
@@ -1664,8 +1660,7 @@ config_dmraid(){
     [ -n "$1" ] || return 1
 
     IFSOLD=${IFS:-}
-    IFS='
-'
+    IFS=$'\n'
     eindent
 
     for line in $(dmraid $1 ; echo errcode:$?); do


### PR DESCRIPTION
The internal field seperator (IFS) got messed up in commit# 1043bc00e.
While at it, fixed all IFS variables to make it more readable and to
prevent breakage by (automatic) indentation.

This is not (yet) POSIX though, but we are in zsh anyway.

Closes grml/grml#40