### PR TITLE
Make interactive scripts work

### DIFF
--- a/systemd/grml-autoconfig.service
+++ b/systemd/grml-autoconfig.service
@@ -8,8 +8,8 @@ After=rc-local.service
 [Service]
 ExecStart=/etc/init.d/grml-autoconfig
 Type=oneshot
+StandardInput=tty
 StandardOutput=tty
-StandardError=journal+console
 
 [Install]
 WantedBy=grml-boot.target


### PR DESCRIPTION
Effectively connect stdin/stdout/stderr to /dev/console. Fixes grml/grml#71.