### PR TITLE
if multiple mountpoints avail, pick the first one

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -1412,7 +1412,7 @@ else
     else
       eindent
       einfo "debs, config, scripts are read from $DCSDEVICE." ; eend 0
-      DCSDIR="$(< /proc/mounts awk -v DCSDEV=$DCSDEVICE '{if ($1 == DCSDEV) { print $2 }}')"
+      DCSDIR="$(< /proc/mounts awk -v DCSDEV=$DCSDEVICE '{if ($1 == DCSDEV) { print $2; exit }}')"
       if [ -n "$DCSDIR" ]; then
         ewarn "$DCSDEVICE already mounted on $DCSDIR"; eend 0
       else


### PR DESCRIPTION
If I put the ISO to hard disk (e.g sda1) and also label that GRMLCFG I get an error:

```
[  OK  ] Searching for device(s) labeled with GRMLCFG. (Disable this via boot option: noautoconfig)
[  OK  ] debs, config, scripts are read from /dev/sda1.
[ WARN ] /dev/sda1 already mounted on /run/live/findiso
/usr/lib/live/mount/findiso
[  OK  ] Debs, config, scripts (if present) will be read from /run/live/findiso
/usr/lib/live/mount/findiso.
config_config:cd:4: no such file or directory: /run/live/findiso\n/usr/lib/live/mount/findiso
[  OK  ] Trying to execute /run/live/findiso
/usr/lib/live/mount/findiso/scripts/
sh: 1: /run/live/findiso: Permission denied
sh: 2: /usr/lib/live/mount/findiso/scripts/: not found
[ WARN ] No soundcard present, skipping mixer settings therefore.
[  OK  ] Starting gpm in background.
```

The findiso mechanism mounts sda1 twice and when trying to find that mountpoint the script fails.
I suggest to pick the first mountpoint.