### PR TITLE
rewrite password generation for more secure and convivial options

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -139,19 +139,15 @@ checkgrmlsmall(){
 set_passwd() {
   [ -n "$PASSWD" ] && return 0
 
-  if [ -x /usr/bin/apg ] ; then
-    PASSWD="$(apg -M NL -a 0 -m 8 -x 12 -n 1)"
-  elif [ -x /usr/bin/gpw ] ; then
-    PASSWD="$(gpw 1)"
-  elif [ -x /usr/bin/pwgen ] ; then
-    PASSWD="$(pwgen -1 8)"
-  elif [ -x /usr/bin/hexdump ] ; then
-    PASSWD="$(dd if=/dev/urandom bs=14 count=1 2>/dev/null | hexdump | awk '{print $3 $4}')"
-  elif [ -n "$RANDOM" ] ; then
-    PASSWD="grml${RANDOM}"
+  if [ -x /usr/bin/xkcdpass ] ; then
+    PASSWORD="$(xkcdpass)"
+  elif [ -x /usr/bin/diceware ] ; then
+    PASSWORD="$(diceware)"
+  elif [ -x /usr/bin/tr ] && [ -x /usr/bin/head ] ; then
+    PASSWORD="$(tr -dc '[:alnum:]' < /dev/urandom | head -c 28)"
   else
     PASSWD=''
-    eerror "Empty passphrase and neither apg, gpw, pwgen, hexdump nor \$RANDOM available. Skipping."
+    eerror "Empty passphrase and neither xkcdpass, diceware, or tr and head available. Skipping."
     eend 1
     return 1
   fi


### PR DESCRIPTION
When I boot a GRML system with `ssh` (without arguments) right now, it generates a 8 character, hex password. Now, I'm not a cryptographer, but I believe that gives about 32 bits of entropy (log2(16)*8), roughly the equivalent of a 8 character, all lowercase, [a-z] password, which is now widely recognized to be extremely poor.

That password is generated by dumping random bytes and piping them into hexdump, taking the first four bytes (hey, look, 32 bits again).

There are other routines in there: if pwgen, gpw, or apg are available, they are used. But pwgen was dropped from in 2009 (#511613), and gpw is not present at all.

apg *is* in GRML_FULL, but I would argue it fares as poorly as hexdump: with the given configuration, it also generates a 8 to 12 character, lowercase and digits "pronouncable" password. It's hard to estimate the damage the "pronouncable" algorithm does to the entropy, but even just relying on the 36 character possibilities (26 + 10), we end up with a meager 41 bits of entropy on those passwords.

In comparison, the passwords generated by diceware and xkcdpass each use 6 words from a ~8000 words dictionnary, which adds up to a whopping 77 bits of entropy, while still generating a rememberable password, much more than apg or pwgen.

If those are not available, we fall back to a much simpler routine: extract alphanumeric characters from /dev/urandom (non-depleting), and dump 28 characters, which gives us 167 bits of entropy.

I'm not directly proposing to install diceware or xkcdpass here yet, but I believe that would also be a nice addition (and I would deprecate apg).

That's a different discussion, however: let's get rid of 8-character passwords for now, first.