### PR TITLE
Drop CONSOLEFONT, KDEKEYBOARD, KDEKEYBOARDS

### DIFF
--- a/autoconfig
+++ b/autoconfig
@@ -22,9 +22,6 @@
 
 ## These are the options you might want to adjust: #############################
 
-# set console font, default: Lat15-Terminus16
-# CONSOLEFONT='iso15graf-16'
-
 # check for frequency-scalable CPU and activate cpydyn/powernowd (default: yes)
 CONFIG_CPU='yes'
 

--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -196,7 +196,7 @@ config_language(){
   einfo "Activating language settings:"
   eindent
 
-  # people can specify $LANGUAGE and $CONSOLEFONT in a config file
+  # people can specify $LANGUAGE in a config file
   [ -r /etc/grml/autoconfig ] && . /etc/grml/autoconfig
 
   # check for bootoption which overrides config from /etc/grml/autoconfig

--- a/language-functions
+++ b/language-functions
@@ -220,7 +220,6 @@ case "$LANGUAGE" in
                 LANG="fr_FR.ISO-8859-1"
                 KEYTABLE="cf"
                 CHARSET="iso8859-1"
-                CONSOLEFONT="Lat15-Terminus16"
                 XKEYBOARD="ca_enhanced"
                 KDEKEYBOARD="ca_enhanced"
                 KDEKEYBOARDS="us"
@@ -262,7 +261,6 @@ case "$LANGUAGE" in
                 CHARSET="iso8859-2"
                 KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Prague"
-                CONSOLEFONT="Lat2-Terminus16"
                 CHARMAP="iso02"
                 ;;
         cs|cz|cs-utf8|cz-utf8)
@@ -277,7 +275,6 @@ case "$LANGUAGE" in
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Prague"
-                CONSOLEFONT="iso02g"
                 ;;
         de-iso)
                 # German version
@@ -392,7 +389,6 @@ case "$LANGUAGE" in
                 XKEYBOARD="us,el"
                 KDEKEYBOARD="us"
                 CHARSET="iso8859-7"
-                CONSOLEFONT="iso07.f16"
                 IOCHARSET="8859-7"
                 IOCODEPAGE="737"
                 SYSFONTACM="iso07"
@@ -409,7 +405,6 @@ case "$LANGUAGE" in
                 XKEYBOARD="us,el"
                 KDEKEYBOARD="us"
                 CHARSET="utf8"
-                CONSOLEFONT="iso07.f16"
                 IOCHARSET="8859-7"
                 IOCODEPAGE="737"
                 SYSFONTACM="iso07"
@@ -440,7 +435,6 @@ case "$LANGUAGE" in
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Madrid"
-                CONSOLEFONT="Lat15-Terminus16"
                 ;;
         fi-iso)
                 # Finnish version
@@ -676,7 +670,6 @@ case "$LANGUAGE" in
                 CHARSET="iso8859-2"
                 KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Warsaw"
-                CONSOLEFONT="Lat2-Terminus16"
                 CHARMAP="iso02"
                 ;;
         pl|pl-utf8)
@@ -691,7 +684,6 @@ case "$LANGUAGE" in
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Warsaw"
-                CONSOLEFONT="iso02g"
                 ;;
         pt-iso)
                 # Portuguese version
@@ -704,7 +696,6 @@ case "$LANGUAGE" in
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Lisbon"
-                CONSOLEFONT="Lat15-Terminus16"
                 ;;
         pt|pt-utf8)
                 # Portuguese version (UTF8)
@@ -718,7 +709,6 @@ case "$LANGUAGE" in
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Lisbon"
-                CONSOLEFONT="Lat15-Terminus16"
                 ;;
         ru-iso)
                 # Russian version
@@ -728,7 +718,6 @@ case "$LANGUAGE" in
                 XKEYBOARD="ru"
                 KDEKEYBOARD="ru"
                 CHARSET="koi8-r"
-                CONSOLEFONT="Cyr_a8x16"
                 KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Moscow"
                 ;;
@@ -741,7 +730,6 @@ case "$LANGUAGE" in
                 XKEYBOARD="ru"
                 KDEKEYBOARD="ru"
                 CHARSET="utf8"
-                CONSOLEFONT="Cyr_a8x16"
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Moscow"
@@ -782,7 +770,6 @@ case "$LANGUAGE" in
                 CHARSET="iso8859-2"
                 KDEKEYBOARDS="us,de"
                 TZ="Europe/Bratislava"
-                CONSOLEFONT="Lat2-Terminus16"
                 CHARMAP="iso02"
                 ;;
         sk|sk-utf8)
@@ -797,7 +784,6 @@ case "$LANGUAGE" in
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="us,de"
                 TZ="Europe/Bratislava"
-                CONSOLEFONT="iso02g"
                 ;;
         sl-iso)
                 # Slovenian keyboard
@@ -810,7 +796,6 @@ case "$LANGUAGE" in
                 CHARSET="iso8859-2"
                 KDEKEYBOARDS="us,de"
                 TZ="Europe/Ljubljana"
-                CONSOLEFONT="Lat2-Terminus16"
                 CHARMAP="iso02"
                 ;;
         sl|sl-utf8)
@@ -825,7 +810,6 @@ case "$LANGUAGE" in
                 # Additional KDE Keyboards
                 KDEKEYBOARDS="us,de"
                 TZ="Europe/Ljubljana"
-                CONSOLEFONT="iso02g"
                 ;;
         tr-iso)
                 # Turkish version (guessed)

--- a/language-functions
+++ b/language-functions
@@ -18,9 +18,7 @@ case "$LANGUAGE" in
                 LANGUAGE="de_AT:de"
                 KEYTABLE="de-latin1-nodeadkeys"
                 XKEYBOARD="de"
-                KDEKEYBOARD="de"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="us,fr"
                 TZ="Europe/Vienna"
                 ;;
         at|at-utf8)
@@ -30,10 +28,8 @@ case "$LANGUAGE" in
                 LANGUAGE="de_AT:de"
                 KEYTABLE="de-latin1-nodeadkeys"
                 XKEYBOARD="de"
-                KDEKEYBOARD="de"
                 CHARSET="utf8"
                 # CHARSET="lat9w-16"
-                KDEKEYBOARDS="us,fr"
                 TZ="Europe/Vienna"
                 ;;
         au-iso)
@@ -43,10 +39,7 @@ case "$LANGUAGE" in
                 LANG="en_AU"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="iso8859-1"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,fr"
                 TZ="Australia/Sydney"
                 ;;
         au|au-utf8)
@@ -56,10 +49,7 @@ case "$LANGUAGE" in
                 LANG="en_AU.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,fr"
                 TZ="Australia/Sydney"
                 ;;
         be-iso|bed-iso)
@@ -69,9 +59,7 @@ case "$LANGUAGE" in
                 LANG="C"
                 KEYTABLE="be2-latin1"
                 XKEYBOARD="be"
-                KDEKEYBOARD="be"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Brussels"
                 ;;
         be|be-utf8|bed|bed-utf8)
@@ -81,10 +69,7 @@ case "$LANGUAGE" in
                 LANG="nl_BE.UTF-8"
                 KEYTABLE="be2-latin1"
                 XKEYBOARD="be"
-                KDEKEYBOARD="be"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Brussels"
                 ;;
         bef-iso)
@@ -94,9 +79,7 @@ case "$LANGUAGE" in
                 LANG="C"
                 KEYTABLE="be2-latin1"
                 XKEYBOARD="be"
-                KDEKEYBOARD="be"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Brussels"
                 ;;
         bef|bef-utf8)
@@ -106,10 +89,7 @@ case "$LANGUAGE" in
                 LANG="fr_BE.UTF-8"
                 KEYTABLE="be2-latin1"
                 XKEYBOARD="be"
-                KDEKEYBOARD="be"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Brussels"
                 ;;
         beg-iso)
@@ -119,9 +99,7 @@ case "$LANGUAGE" in
                 LANG="C"
                 KEYTABLE="be2-latin1"
                 XKEYBOARD="be"
-                KDEKEYBOARD="be"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Brussels"
                 ;;
         beg|beg-utf8)
@@ -131,10 +109,7 @@ case "$LANGUAGE" in
                 LANG="de_BE.UTF-8"
                 KEYTABLE="be2-latin1"
                 XKEYBOARD="be"
-                KDEKEYBOARD="be"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Brussels"
                 ;;
         bg-iso)
@@ -144,9 +119,7 @@ case "$LANGUAGE" in
                 LANG="bg_BG"
                 KEYTABLE="bg"
                 XKEYBOARD="bg"
-                KDEKEYBOARD="bg"
                 CHARSET="microsoft-cp1251"
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Sofia"
                 ;;
         bg|bg-utf8)
@@ -156,10 +129,7 @@ case "$LANGUAGE" in
                 LANG="bg_BG.UTF-8"
                 KEYTABLE="bg"
                 XKEYBOARD="bg"
-                KDEKEYBOARD="bg"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Sofia"
                 ;;
         br-iso)
@@ -169,10 +139,7 @@ case "$LANGUAGE" in
                 LANG="pt_BR"
                 KEYTABLE="br-abnt2"
                 XKEYBOARD="abnt2"
-                KDEKEYBOARD="br"
                 CHARSET="iso8859-1"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,br"
                 TZ="America/Sao_Paulo"
                 ;;
         br|br-utf8)
@@ -182,10 +149,7 @@ case "$LANGUAGE" in
                 LANG="pt_BR.UTF-8"
                 KEYTABLE="br-abnt2"
                 XKEYBOARD="abnt2"
-                KDEKEYBOARD="br"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,br"
                 TZ="America/Sao_Paulo"
                 ;;
         ch-iso)
@@ -195,9 +159,7 @@ case "$LANGUAGE" in
                 LANG="de_CH"
                 KEYTABLE="sg-latin1"
                 XKEYBOARD="ch"
-                KDEKEYBOARD="ch"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Zurich"
                 ;;
         ch|ch-utf8)
@@ -207,10 +169,7 @@ case "$LANGUAGE" in
                 LANG="de_CH.UTF-8"
                 KEYTABLE="sg-latin1"
                 XKEYBOARD="ch"
-                KDEKEYBOARD="ch"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Zurich"
                 ;;
         cf)
@@ -221,8 +180,6 @@ case "$LANGUAGE" in
                 KEYTABLE="cf"
                 CHARSET="iso8859-1"
                 XKEYBOARD="ca_enhanced"
-                KDEKEYBOARD="ca_enhanced"
-                KDEKEYBOARDS="us"
                 TZ="America/Montreal"
                 ;;
         cn-iso)
@@ -231,9 +188,7 @@ case "$LANGUAGE" in
                 LANG="zh_CN.GB2312"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="gb2312.1980-0"
-                KDEKEYBOARDS="us,de,fr"
                 XMODIFIERS="@im=Chinput"
                 TZ="Asia/Shanghai"
                 ;;
@@ -243,10 +198,7 @@ case "$LANGUAGE" in
                 LANG="zh_CN.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de,fr"
                 XMODIFIERS="@im=Chinput"
                 TZ="Asia/Shanghai"
                 ;;
@@ -257,9 +209,7 @@ case "$LANGUAGE" in
                 LANG="cs_CZ"
                 KEYTABLE="cz-lat2"
                 XKEYBOARD="cs"
-                KDEKEYBOARD="cz"
                 CHARSET="iso8859-2"
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Prague"
                 CHARMAP="iso02"
                 ;;
@@ -270,10 +220,7 @@ case "$LANGUAGE" in
                 LANG="cs_CZ.UTF-8"
                 KEYTABLE="cz-lat2"
                 XKEYBOARD="cs"
-                KDEKEYBOARD="cs"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Prague"
                 ;;
         de-iso)
@@ -283,9 +230,7 @@ case "$LANGUAGE" in
                 LANGUAGE="de_DE:de"
                 KEYTABLE="de-latin1-nodeadkeys"
                 XKEYBOARD="de"
-                KDEKEYBOARD="de"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="us,fr"
                 TZ="Europe/Berlin"
                 ;;
         de|de-utf8)
@@ -295,10 +240,7 @@ case "$LANGUAGE" in
                 LANGUAGE="de_DE:de"
                 KEYTABLE="de-latin1-nodeadkeys"
                 XKEYBOARD="de"
-                KDEKEYBOARD="de"
                 CHARSET="utf8"
-                # CHARSET="lat9w-16"
-                KDEKEYBOARDS="us,fr"
                 TZ="Europe/Berlin"
                 ;;
         dk-iso|da-iso)
@@ -310,9 +252,7 @@ case "$LANGUAGE" in
                 # Keytable "dk" is correct.
                 KEYTABLE="dk"
                 XKEYBOARD="dk"
-                KDEKEYBOARD="dk"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="dk,de,us,fr"
                 TZ="Europe/Copenhagen"
                 ;;
         dk|da|dk-utf8|da-utf8)
@@ -324,10 +264,7 @@ case "$LANGUAGE" in
                 # Keytable "dk" is correct.
                 KEYTABLE="dk"
                 XKEYBOARD="dk"
-                KDEKEYBOARD="dk"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="dk,de,us,fr"
                 TZ="Europe/Copenhagen"
                 ;;
         dvorak|dvorak-utf8)
@@ -337,9 +274,7 @@ case "$LANGUAGE" in
                 LANG="en_US.UTF-8"
                 KEYTABLE="dvorak"
                 XKEYBOARD="dvorak"
-                KDEKEYBOARD="dvorak,us,de"
                 CHARSET="utf8"
-                KDEKEYBOARDS="dvorak,us,de,fr"
                 TZ="UTC"
                 ;;
         dvorak-iso)
@@ -349,9 +284,7 @@ case "$LANGUAGE" in
                 LANG="en_US.iso885915"
                 KEYTABLE="dvorak"
                 XKEYBOARD="dvorak"
-                KDEKEYBOARD="dvorak,us,de"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="dvorak,us,de,fr"
                 TZ="UTC"
                 ;;
         en-iso)
@@ -362,9 +295,7 @@ case "$LANGUAGE" in
                 LANG="en_US.iso885915"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="de,fr"
                 TZ="UTC"
                 ;;
         en|en-utf8)
@@ -374,10 +305,7 @@ case "$LANGUAGE" in
                 LANG="en_US.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,fr"
                 TZ="UTC"
                 ;;
         el-iso)
@@ -387,13 +315,10 @@ case "$LANGUAGE" in
                 LANG="el_GR"
                 KEYTABLE="gr"
                 XKEYBOARD="us,el"
-                KDEKEYBOARD="us"
                 CHARSET="iso8859-7"
                 IOCHARSET="8859-7"
                 IOCODEPAGE="737"
                 SYSFONTACM="iso07"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="el"
                 TZ="Europe/Athens"
                 ;;
         el|el-utf8)
@@ -403,13 +328,10 @@ case "$LANGUAGE" in
                 LANG="el_GR.UTF-8"
                 KEYTABLE="gr-utf8"
                 XKEYBOARD="us,el"
-                KDEKEYBOARD="us"
                 CHARSET="utf8"
                 IOCHARSET="8859-7"
                 IOCODEPAGE="737"
                 SYSFONTACM="iso07"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="el"
                 TZ="Europe/Athens"
                 ;;
         es-iso)
@@ -418,9 +340,7 @@ case "$LANGUAGE" in
                 LANG="es_ES@euro"
                 KEYTABLE="es"
                 XKEYBOARD="es"
-                KDEKEYBOARD="es"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Madrid"
                 ;;
         es|es-utf8)
@@ -430,10 +350,7 @@ case "$LANGUAGE" in
                 LANG="es_ES.UTF-8"
                 KEYTABLE="es"
                 XKEYBOARD="es"
-                KDEKEYBOARD="es"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Madrid"
                 ;;
         fi-iso)
@@ -442,9 +359,7 @@ case "$LANGUAGE" in
                 LANG="fi_FI@euro"
                 KEYTABLE="fi-latin1" # old value: fi
                 XKEYBOARD="fi"
-                KDEKEYBOARD="fi"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="se,us"
                 TZ="Europe/Helsinki"
                 ;;
         fi|fi-utf8)
@@ -454,10 +369,7 @@ case "$LANGUAGE" in
                 LANG="fi_FI.UTF-8"
                 KEYTABLE="fi-latin1"
                 XKEYBOARD="fi"
-                KDEKEYBOARD="fi"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us"
                 TZ="Europe/Helsinki"
                 ;;
         fr-iso)
@@ -466,9 +378,7 @@ case "$LANGUAGE" in
                 LANG="fr_FR@euro"
                 KEYTABLE="fr"
                 XKEYBOARD="fr"
-                KDEKEYBOARD="fr"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="de,us"
                 TZ="Europe/Paris"
                 ;;
         fr|fr-utf8)
@@ -478,10 +388,7 @@ case "$LANGUAGE" in
                 LANG="fr_FR.UTF-8"
                 KEYTABLE="fr"
                 XKEYBOARD="fr"
-                KDEKEYBOARD="fr"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,us"
                 TZ="Europe/Paris"
                 ;;
         ga-iso)
@@ -490,10 +397,7 @@ case "$LANGUAGE" in
                 LANG="ga_IE@euro"
                 KEYTABLE="uk"
                 XKEYBOARD="uk"
-                KDEKEYBOARD="ie"
                 CHARSET="iso8859-15"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="gb,us,de,es,fr,it"
                 TZ="Europe/Dublin"
                 ;;
         ga|ga-utf8)
@@ -502,10 +406,7 @@ case "$LANGUAGE" in
                 LANG="ga_IE@UTF-8"
                 KEYTABLE="uk"
                 XKEYBOARD="uk"
-                KDEKEYBOARD="ie"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="gb,us,de,es,fr,it"
                 TZ="Europe/Dublin"
                 ;;
         he-iso|il-iso)
@@ -515,9 +416,7 @@ case "$LANGUAGE" in
                 LANG="he_IL"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="il"
                 CHARSET="iso8859-8"
-                KDEKEYBOARDS="us,fr,de"
                 TZ="Asia/Jerusalem"
                 ;;
         he|il|he-utf8|il-utf8)
@@ -527,10 +426,7 @@ case "$LANGUAGE" in
                 LANG="he_IL.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="il"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,fr,de"
                 TZ="Asia/Jerusalem"
                 ;;
         ie-iso)
@@ -539,9 +435,7 @@ case "$LANGUAGE" in
                 LANG="en_IE@euro"
                 KEYTABLE="uk"
                 XKEYBOARD="uk"
-                KDEKEYBOARD="gb"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="us,de,es,fr,it"
                 TZ="Europe/Dublin"
                 ;;
         ie|ie-utf8)
@@ -551,10 +445,7 @@ case "$LANGUAGE" in
                 LANG="en_IE.UTF-8"
                 KEYTABLE="uk"
                 XKEYBOARD="uk"
-                KDEKEYBOARD="ie"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="gb,us,de,es,fr,it"
                 TZ="Europe/Dublin"
                 ;;
         it-iso)
@@ -563,9 +454,7 @@ case "$LANGUAGE" in
                 LANG="it_IT@euro"
                 KEYTABLE="it"
                 XKEYBOARD="it"
-                KDEKEYBOARD="it"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="fr,us,de"
                 TZ="Europe/Rome"
                 ;;
         it|it-utf8)
@@ -575,10 +464,7 @@ case "$LANGUAGE" in
                 LANG="it_IT.UTF-8"
                 KEYTABLE="it"
                 XKEYBOARD="it"
-                KDEKEYBOARD="it"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="fr,us,de"
                 TZ="Europe/Rome"
                 ;;
         ja-iso|jp-iso)
@@ -589,9 +475,7 @@ case "$LANGUAGE" in
                 KEYTABLE="jp106"
                 XKEYMODEL="jp106"
                 XKEYBOARD="jp"
-                KDEKEYBOARD="us"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="fr,us,de"
                 TZ="Asia/Tokyo"
                 ;;
         ja|ja-utf8|jp|jp-utf8)
@@ -603,10 +487,7 @@ case "$LANGUAGE" in
                 KEYTABLE="jp106"
                 XKEYMODEL="jp106"
                 XKEYBOARD="jp"
-                KDEKEYBOARD="us"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="fr,us,de"
                 TZ="Asia/Tokyo"
                 ;;
         nl-iso)
@@ -615,9 +496,7 @@ case "$LANGUAGE" in
                 LANG="nl_NL@euro"
                 KEYTABLE="us" # nl
                 XKEYBOARD="us" # nl
-                KDEKEYBOARD="en_US" # nl
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="nl,de,fr"
                 TZ="Europe/Amsterdam"
                 ;;
         nl|nl-utf8)
@@ -627,10 +506,7 @@ case "$LANGUAGE" in
                 LANG="nl_NL.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="en_US"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="nl,de,fr"
                 TZ="Europe/Amsterdam"
                 ;;
         no-iso|nb-iso|nn-iso)
@@ -640,9 +516,7 @@ case "$LANGUAGE" in
                 LANGUAGE="no:nb_NO"
                 KEYTABLE="no"
                 XKEYBOARD="no"
-                KDEKEYBOARD="no"
                 CHARSET="iso8859-15"
-                KDEKEYBOARDS="no-latin1,us,no,no-dvorak"
                 TZ="Europe/Oslo"
                 ;;
         no|nb|nn|no-utf8|nb-utf8|nn-utf8)
@@ -655,9 +529,7 @@ case "$LANGUAGE" in
                 # Otherwise try the other variants no-latin1 etc.
                 KEYTABLE="no"
                 XKEYBOARD="no"
-                KDEKEYBOARD="no"
                 CHARSET="utf8"
-                KDEKEYBOARDS="no,us,no-dvorak,dk,no-latin1"
                 TZ="Europe/Oslo"
                 ;;
         pl-iso)
@@ -666,9 +538,7 @@ case "$LANGUAGE" in
                 LANG="pl_PL"
                 KEYTABLE="pl"
                 XKEYBOARD="pl"
-                KDEKEYBOARD="pl"
                 CHARSET="iso8859-2"
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Warsaw"
                 CHARMAP="iso02"
                 ;;
@@ -679,10 +549,7 @@ case "$LANGUAGE" in
                 LANG="pl_PL.UTF-8"
                 KEYTABLE="pl"
                 XKEYBOARD="pl"
-                KDEKEYBOARD="pl"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Warsaw"
                 ;;
         pt-iso)
@@ -691,10 +558,7 @@ case "$LANGUAGE" in
                 LANG="pt_PT@euro"
                 KEYTABLE="pt-latin1"
                 XKEYBOARD="pt"
-                KDEKEYBOARD="pt"
                 CHARSET="iso8859-1"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Lisbon"
                 ;;
         pt|pt-utf8)
@@ -704,10 +568,7 @@ case "$LANGUAGE" in
                 LANG="pt_PT.UTF-8"
                 KEYTABLE="pt-latin1"
                 XKEYBOARD="pt"
-                KDEKEYBOARD="pt"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Lisbon"
                 ;;
         ru-iso)
@@ -716,9 +577,7 @@ case "$LANGUAGE" in
                 LANG="ru_RU.KOI8-R"
                 KEYTABLE="ru"
                 XKEYBOARD="ru"
-                KDEKEYBOARD="ru"
                 CHARSET="koi8-r"
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Moscow"
                 ;;
         ru|ru-utf8)
@@ -728,10 +587,7 @@ case "$LANGUAGE" in
                 LANG="ru_RU.UTF-8"
                 KEYTABLE="ru"
                 XKEYBOARD="ru"
-                KDEKEYBOARD="ru"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,us,fr"
                 TZ="Europe/Moscow"
                 ;;
         se-iso)
@@ -741,10 +597,7 @@ case "$LANGUAGE" in
                 LANG="sv_SE.iso885915"
                 KEYTABLE="se-latin1"
                 XKEYBOARD="se"
-                KDEKEYBOARD="se"
                 CHARSET="sv_SE.iso885915"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,fi"
                 TZ="Europe/Stockholm"
                 ;;
         se|se-utf8)
@@ -754,10 +607,7 @@ case "$LANGUAGE" in
                 LANG="sv_SE.utf8"
                 KEYTABLE="se-latin1"
                 XKEYBOARD="se"
-                KDEKEYBOARD="se"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,fi"
                 TZ="Europe/Stockholm"
                 ;;
         sk-iso)
@@ -766,9 +616,7 @@ case "$LANGUAGE" in
                 LANG="sk"
                 KEYTABLE="sk-qwerty"
                 XKEYBOARD="sk"
-                KDEKEYBOARD="sk"
                 CHARSET="iso8859-2"
-                KDEKEYBOARDS="us,de"
                 TZ="Europe/Bratislava"
                 CHARMAP="iso02"
                 ;;
@@ -779,10 +627,7 @@ case "$LANGUAGE" in
                 LANG="sk_SK.UTF-8"
                 KEYTABLE="sk-qwerty"
                 XKEYBOARD="sk"
-                KDEKEYBOARD="sk"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de"
                 TZ="Europe/Bratislava"
                 ;;
         sl-iso)
@@ -792,9 +637,7 @@ case "$LANGUAGE" in
                 LANG="sl_SI"
                 KEYTABLE="slovene"
                 XKEYBOARD="sl"
-                KDEKEYBOARD="si"
                 CHARSET="iso8859-2"
-                KDEKEYBOARDS="us,de"
                 TZ="Europe/Ljubljana"
                 CHARMAP="iso02"
                 ;;
@@ -805,10 +648,7 @@ case "$LANGUAGE" in
                 LANG="sl_SI.UTF-8"
                 KEYTABLE="slovene"
                 XKEYBOARD="sl"
-                KDEKEYBOARD="si"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de"
                 TZ="Europe/Ljubljana"
                 ;;
         tr-iso)
@@ -817,9 +657,7 @@ case "$LANGUAGE" in
                 LANG="tr_TR"
                 KEYTABLE="tr_q-latin5"
                 XKEYBOARD="tr"
-                KDEKEYBOARD="tr"
                 CHARSET="iso8859-9"
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Istanbul"
                 ;;
         tr|tr-utf8)
@@ -829,10 +667,7 @@ case "$LANGUAGE" in
                 LANG="tr_TR.UTF-8"
                 KEYTABLE="tr_q-latin5"
                 XKEYBOARD="tr"
-                KDEKEYBOARD="tr"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us,de,fr"
                 TZ="Europe/Istanbul"
                 ;;
         tw-iso)
@@ -842,10 +677,8 @@ case "$LANGUAGE" in
                 LANGUAGE="zh_TW.Big5"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 # CHARSET="big5-0"
                 CHARSET="iso8859-1"
-                KDEKEYBOARDS="us"
                 XMODIFIERS="@im=xcin"
                 TZ="Asia/Taipei"
                 ;;
@@ -856,11 +689,8 @@ case "$LANGUAGE" in
                 LANG="zh_TW.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 # CHARSET="big5-0"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us"
                 XMODIFIERS="@im=xcin"
                 TZ="Asia/Taipei"
                 ;;
@@ -871,9 +701,7 @@ case "$LANGUAGE" in
                 LANGUAGE="en"
                 KEYTABLE="uk"
                 XKEYBOARD="uk"
-                KDEKEYBOARD="gb"
                 CHARSET="iso8859-1"
-                KDEKEYBOARDS="us"
                 TZ="Europe/London"
                 ;;
         uk|uk-utf8)
@@ -883,10 +711,7 @@ case "$LANGUAGE" in
                 LANG="en_GB.UTF-8"
                 KEYTABLE="uk"
                 XKEYBOARD="uk"
-                KDEKEYBOARD="gb"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="us"
                 TZ="Europe/London"
                 ;;
         us-iso)
@@ -896,10 +721,7 @@ case "$LANGUAGE" in
                 LANG="en_US.iso885915"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="en_US.iso885915"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,fr"
                 TZ="America/New_York"
                 ;;
         us|us-utf8)
@@ -909,10 +731,7 @@ case "$LANGUAGE" in
                 LANG="en_US.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="utf8"
-                # Additional KDE Keyboards
-                KDEKEYBOARDS="de,fr"
                 TZ="America/New_York"
                 ;;
         *)
@@ -922,9 +741,7 @@ case "$LANGUAGE" in
                 LANG="en_US.UTF-8"
                 KEYTABLE="us"
                 XKEYBOARD="us"
-                KDEKEYBOARD="us"
                 CHARSET="utf8"
-                KDEKEYBOARDS="de,fr"
                 TZ="UTC"
                 ;;
 esac


### PR DESCRIPTION
These were guarded by an if !SYSTEMD clause since fc67c1849a4eed7c2c0586dd65d77cec7d053768
and was removed completely in 4f89bd4a26316b23921330a77e23ca6791f9b6bb.

grml-lang also doesn't use them.
