### PR TITLE
Stop managing rsyslog

### DIFF
--- a/autoconfig
+++ b/autoconfig
@@ -32,9 +32,6 @@ CONFIG_FSTAB_USER='grml'
 # define guid for rebuildfstab used in /etc/fstab (default: users):
 CONFIG_FSTAB_GROUP='users'
 
-# start syslog-ng (default: yes)
-CONFIG_SYSLOG='yes'
-
 # start gpm (default: yes)
 CONFIG_GPM='yes'
 

--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -897,18 +897,6 @@ config_mixer () {
 }
 # }}}
 
-# {{{ syslog service
-config_syslog(){
- if checkbootparam 'nosyslog'; then
-    ewarn "Not starting syslog daemon as requested on boot commandline." ; eend 0
- else
-    einfo "Starting rsyslog in background."
-    service_wrapper rsyslog start >>$DEBUG
-    eend 0
- fi
-}
-# }}}
-
 # {{{ gpm
 config_gpm(){
   if checkbootparam 'nogpm'; then

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,6 @@ Depends:
  grml-scripts (>= 0.8-14),
  kbd | console-utilities,
  rsync,
- rsyslog | system-log-daemon,
  udev,
  util-linux-extra | util-linux (<= 2.38-1),
  zsh,

--- a/grml-autoconfig
+++ b/grml-autoconfig
@@ -24,8 +24,6 @@ source /etc/grml/lsb-functions         # helper functions for smart display
 
 # {{{ main grml-autoconfig
 
-checkvalue $CONFIG_SYSLOG && config_syslog
-
 if checkbootparam 'forensic' ; then
    ewarn "Bootopion forensic found. Important notice:" ; eend 0
    ewarn " Do *NOT* boot with something like 'grml forensic ...' but always use 'forensic ...' instead!" ; eend 0

--- a/sbin/grml-autoconfig
+++ b/sbin/grml-autoconfig
@@ -53,7 +53,6 @@ check_current_state()
 {
   is_set $CONFIG_FSTAB      && FSTABSTATUS=ON    || FSTABSTATUS=OFF
   is_set $CONFIG_CPU        && CPUSTATUS=ON      || CPUSTATUS=OFF
-  is_set $CONFIG_SYSLOG     && SYSLOGSTATUS=ON   || SYSLOGSTATUS=OFF
   is_set $CONFIG_GPM        && GPMSTATUS=ON      || GPMSTATUS=OFF
 }
 
@@ -76,7 +75,6 @@ settings in /etc/network/interfaces, it just configures grml-autoconfig
 " 0 0 0 \
 fstab "update /etc/fstab entries (check for devices)" $FSTABSTATUS \
 cpufreq "activate cpu frequency scaling" $CPUSTATUS \
-syslog "start syslog-ng" $SYSLOGSTATUS \
 gpm "start GPM (mouse on console)" $GPMSTATUS \
   2>$TMPFILE
 }
@@ -85,7 +83,6 @@ set_values()
 {
   check_setting fstab     && activate_value CONFIG_FSTAB=    || deactivate_value CONFIG_FSTAB=
   check_setting cpufreq   && activate_value CONFIG_CPU=      || deactivate_value CONFIG_CPU=
-  check_setting syslog    && activate_value CONFIG_SYSLOG=   || deactivate_value CONFIG_SYSLOG=
   check_setting gpm       && activate_value CONFIG_GPM=      || deactivate_value CONFIG_GPM=
 }
 


### PR DESCRIPTION
https://github.com/grml/grml-live/pull/257 attempted to no longer install rsyslog, but this gets fooled by grml-autoconfig depending on it.

Remove the rsyslog dependency and any startup code for it.