### PR TITLE
Set timezone before timedatectl set-local-rtc 1

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -355,25 +355,22 @@ config_timezone(){
   local timezone
   timezone="$(getbootparam 'tz' 2>>$DEBUG)"
 
+  if [ -n "${timezone}" ] ; then
+    if ! [ -e "/usr/share/zoneinfo/${timezone}" ] ; then
+      ewarn "Warning: unknown timezone ${timezone}, falling back to UTC" ; eend 1
+      timezone="UTC"
+    fi
+
+    einfo "Setting timezone to ${timezone}"
+    ln -sf /usr/share/zoneinfo/"${timezone}" /etc/localtime
+    eend $?
+  fi
+
   if checkbootparam 'localtime' ; then
     einfo "Bootoption localtime is set, configuring RTC to local time."
     timedatectl set-local-rtc 1
     eend $?
   fi
-
-  # nothing further to do for us if boot option isn't set
-  if [ -z "${timezone:-}" ] ; then
-    return 0
-  fi
-
-  if ! [ -e "/usr/share/zoneinfo/${timezone}" ] ; then
-    ewarn "Warning: unknown timezone ${timezone}, falling back to UTC" ; eend 1
-    timezone="UTC"
-  fi
-
-  einfo "Setting timezone to ${timezone}"
-  ln -sf /usr/share/zoneinfo/"${timezone}" /etc/localtime
-  eend $?
 }
 # }}}
 


### PR DESCRIPTION
This is a follow up of e96da70.

When `timedatectl set-local-rtc 1` is called the first time, it triggers a start of systemd-timedated which does some "magic" to calculate the correct time, which, at this time, does not yet have the correct timezone.

We should set timezone before calling timedatectl.

Closes: grml/grml-autoconfig#31