### PR TITLE
Restore console keyboard setup

### DIFF
--- a/autoconfig.functions
+++ b/autoconfig.functions
@@ -239,6 +239,8 @@ config_language(){
 
   fi
 
+  service_wrapper console-setup restart >>$DEBUG 2>&1 ; eend $?
+
   eoutdent
 }
 # }}}


### PR DESCRIPTION
Hello @mika, 

Would appreciate if you could sneak this PR into the upcoming 2025.05 release, as that would make my `keyboard=hu` boot option working as intended again ;-) 

Thanks in advance!

Regards,
János Pásztor